### PR TITLE
Bump PHP to 8.4 + replace azjezz/psl with php-standard-library

### DIFF
--- a/.github/workflows/grumphp.yml
+++ b/.github/workflows/grumphp.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         operating-system: [ubuntu-latest]
-        php-versions: ['8.2', '8.3', '8.4', '8.5']
+        php-versions: ['8.4', '8.5']
         composer-options: ['', '--prefer-lowest']
         composer-versions: ['composer:v2']
       fail-fast: false

--- a/composer.json
+++ b/composer.json
@@ -14,10 +14,13 @@
         }
     },
     "require": {
-        "php": "~8.2.0 || ~8.3.0 || ~8.4.0 || ~8.5.0",
-        "azjezz/psl": "^3.0 || ^4.0",
+        "php": "~8.4.0 || ~8.5.0",
         "doctrine/dbal": "^3.9",
         "jackalope/jackalope-doctrine-dbal": "^2.0",
+        "php-standard-library/foundation": "^6.1",
+        "php-standard-library/str": "^6.1",
+        "php-standard-library/type": "^6.1",
+        "php-standard-library/vec": "^6.1",
         "ramsey/uuid": "^4.7",
         "sulu/sulu": "^2.6 || ^3.0",
         "symfony/clock": "^7.0 || ^8.0",
@@ -29,6 +32,7 @@
     "require-dev": {
         "php-cs-fixer/shim": "^3.58",
         "php-standard-library/psalm-plugin": "^2.3",
+        "php-standard-library/result": "^6.1",
         "phpro/symfony-conventions": "^1.5",
         "phpspec/prophecy-phpunit": "^2.1",
         "phpunit/phpunit": "^9.6",

--- a/src/Infrastructure/Doctrine/Schema/TranslationTable.php
+++ b/src/Infrastructure/Doctrine/Schema/TranslationTable.php
@@ -14,7 +14,7 @@ use function Psl\Vec\map;
 
 final class TranslationTable
 {
-    public const NAME = 'phpro_translations';
+    public const string NAME = 'phpro_translations';
 
     public static function name(): string
     {

--- a/src/Infrastructure/Sulu/Admin/TranslationsAdmin.php
+++ b/src/Infrastructure/Sulu/Admin/TranslationsAdmin.php
@@ -16,12 +16,12 @@ use Sulu\Component\Security\Authorization\SecurityCheckerInterface;
 
 final class TranslationsAdmin extends Admin
 {
-    final public const SECURITY_CONTEXT = 'phpro_translations';
-    private const SECURITY_CONTEXT_GROUP = 'Settings';
-    final public const LIST_KEY = 'phpro_translations_list';
-    private const FORM_KEY = 'phpro_translations_form';
-    private const LIST_VIEW = 'phpro_translations_list_view';
-    private const EDIT_FORM_VIEW = 'phpro_translations_form_view';
+    final public const string SECURITY_CONTEXT = 'phpro_translations';
+    private const string SECURITY_CONTEXT_GROUP = 'Settings';
+    final public const string LIST_KEY = 'phpro_translations_list';
+    private const string FORM_KEY = 'phpro_translations_form';
+    private const string LIST_VIEW = 'phpro_translations_list_view';
+    private const string EDIT_FORM_VIEW = 'phpro_translations_form_view';
 
     public function __construct(
         private readonly ViewBuilderFactoryInterface $viewBuilderFactory,

--- a/src/Infrastructure/Symfony/Translation/Provider/DatabaseProviderFactory.php
+++ b/src/Infrastructure/Symfony/Translation/Provider/DatabaseProviderFactory.php
@@ -12,8 +12,8 @@ use Symfony\Component\Translation\Provider\Dsn;
 
 final class DatabaseProviderFactory extends AbstractProviderFactory
 {
-    public const PROVIDER_NAME = 'phpro_database';
-    public const PROVIDER_DSN_SCHEME = 'database';
+    public const string PROVIDER_NAME = 'phpro_database';
+    public const string PROVIDER_DSN_SCHEME = 'database';
 
     public function __construct(
         private readonly Writer $writer,

--- a/src/Presentation/Controller/Admin/ListController.php
+++ b/src/Presentation/Controller/Admin/ListController.php
@@ -18,7 +18,7 @@ use function Psl\Type\int;
 #[Route(path: '/translations', name: 'phpro.translations_list', options: ['expose' => true], methods: ['GET'])]
 final class ListController extends AbstractSecuredTranslationsController implements SecuredControllerInterface
 {
-    public const RESOURCE_KEY = 'phpro_translations';
+    public const string RESOURCE_KEY = 'phpro_translations';
 
     public function __construct(
         private readonly SerializerInterface $serializer,
@@ -50,7 +50,7 @@ final class ListController extends AbstractSecuredTranslationsController impleme
         $listRepresentation = new PaginatedRepresentation(
             $translationsResult->translationCollection(),
             self::RESOURCE_KEY,
-            (int) $this->listRestHelper->getPage(),
+            int()->coerce($this->listRestHelper->getPage()),
             $limit,
             $translationsResult->totalCount(),
         );


### PR DESCRIPTION
- Bump PHP to 8.4
- Replaced azjezz/psl with seperate php-standard-library packages